### PR TITLE
add permissions for modifying ec2 volumes

### DIFF
--- a/terraform/eks/ec2_postgres.tf
+++ b/terraform/eks/ec2_postgres.tf
@@ -5,10 +5,10 @@ resource "aws_instance" "postgres" {
   key_name               = "${var.hackweek_name}-postgres"
   subnet_id              = module.vpc.public_subnets[0]
   vpc_security_group_ids = [aws_security_group.postgres.id]
-    
+
   tags = {
     Name        = "Postgres machine for ${var.hackweek_name} hackweek"
-    Hackweek    = "${var.hackweek_name}"
+    Hackweek    = var.hackweek_name
   }
 
   root_block_device {

--- a/terraform/setup/iam/main.tf
+++ b/terraform/setup/iam/main.tf
@@ -161,3 +161,15 @@ resource "aws_iam_role_policy_attachment" "github-role-sops" {
   role = aws_iam_role.github-role.name
   policy_arn = aws_iam_policy.github-role-sops.arn
 }
+
+
+# Permissions for modifying postgres volume
+resource "aws_iam_policy" "github-role-postgres" {
+  name = "github-actions-role-postgres"
+  policy = file("postgres-policy.json")
+}
+
+resource "aws_iam_role_policy_attachment" "github-role-postgres" {
+  role = aws_iam_role.github-role.name
+  policy_arn = aws_iam_policy.github-role-postgres.arn
+}

--- a/terraform/setup/iam/postgres-policy.json
+++ b/terraform/setup/iam/postgres-policy.json
@@ -1,0 +1,20 @@
+{
+	"Version": "2012-10-17",
+	"Statement": [{
+		"Sid": "ModifyVolume",
+		"Effect": "Allow",
+		"Action": [
+			"ec2:AttachVolume",
+			"ec2:CreateVolume",
+			"ec2:DescribeVolumeAttribute",
+			"ec2:DescribeVolumeStatus",
+			"ec2:DescribeVolumes",
+			"ec2:DetachVolume",
+			"ec2:EnableVolumeIO",
+			"ec2:ModifyVolumeAttribute",
+			"ec2:ModifyVolume",
+			"ec2:Modify*"
+		],
+		"Resource": "*"
+	}]
+}


### PR DESCRIPTION
followup to failed merge of 31a69b3 . Authorization error `Error: error modifying EC2 Volume "vol-01344c294fd747794": UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure`  

I think we just need to give out CI role permissions to modify volumes, which this PR does