### PR TITLE
create snowex-user iam for s3 access

### DIFF
--- a/terraform/eks/s3-data-bucket.tf
+++ b/terraform/eks/s3-data-bucket.tf
@@ -56,3 +56,18 @@ data "aws_iam_policy_document" "hackweek-bucket-access-permissions" {
     ]
   }
 }
+
+# Also create an IAM user so that we can create temporary credentials to access
+# S3 from anywhere with aws sts get-session-token
+resource "aws_iam_user" "snowex-user" {
+  name = "snowex-user"
+}
+
+resource "aws_iam_access_key" "snowex-user" {
+  user = aws_iam_user.snowex-user.name
+}
+
+resource "aws_iam_user_policy_attachment" "snowex-user" {
+  user       = aws_iam_user.snowex-user.name
+  policy_arn = aws_iam_policy.hackweek-bucket-access-policy.arn
+}


### PR DESCRIPTION
we want tutorial developers to be able to push data to s3 from any machine

this is one solution allowing a hackweek admin to run `aws --profile snowex-user sts get-session-token --duration 129600` and then post those temporary (36 hour) credentials for everyone to use.

Not ideal, but apparently users can't create their own temporary tokens from the hub (`An error occurred (AccessDenied) when calling the GetSessionToken operation: Cannot call GetSessionToken with session credentials`)

https://docs.aws.amazon.com/cli/latest/reference/sts/get-session-token.html