### PR TITLE
allow access to LIS tutorial data bucket

### DIFF
--- a/terraform/eks/s3-data-bucket.tf
+++ b/terraform/eks/s3-data-bucket.tf
@@ -36,7 +36,22 @@ data "aws_iam_policy_document" "hackweek-bucket-access-permissions" {
     ]
 
     resources = [
-      aws_s3_bucket.hackweek-data-bucket.arn
+      aws_s3_bucket.hackweek-data-bucket.arn,
+      "arn:aws:s3:::eis-dh-hydro"
+    ]
+  }
+  
+  statement {
+    sid       = "${var.hackweek_name}DataBucketReadOnly"
+
+    effect    = "Allow"
+
+    actions   = [
+      "s3:GetObject"
+    ]
+
+    resources = [
+      "arn:aws:s3:::eis-dh-hydro"
     ]
   }
 


### PR DESCRIPTION
will allow snowex hackweek hub users read-only access to s3://eis-dh-hydro (LIS data in aws us-east-1)